### PR TITLE
Add a config option to allow disabling of url tagging if the middleware request timings

### DIFF
--- a/config/datadog-helper.php
+++ b/config/datadog-helper.php
@@ -36,6 +36,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Disable tagging request durations with url
+    |--------------------------------------------------------------------------
+    |
+    | Sites with large numbers of unique URIs can cause excessive unique tags for a metric which results
+    | in Datadog being unhappy (to the point of being unresponsive).
+    |
+    */
+    'middleware_disable_url_tag' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Transport
     |--------------------------------------------------------------------------
     |

--- a/src/Middleware/LaravelDatadogMiddleware.php
+++ b/src/Middleware/LaravelDatadogMiddleware.php
@@ -40,9 +40,12 @@ class LaravelDatadogMiddleware
         $duration = microtime(true) - $startTime;
 
         $tags = [
-            "url" => $request->getSchemeAndHttpHost() . $request->getRequestUri(),
             "status_code" => $response->getStatusCode()
         ];
+
+        if (!config('datadog-helper.middleware_disable_url_tag', false)) {
+            $tags["url"] = $request->getSchemeAndHttpHost() . $request->getRequestUri();
+        }
 
         Datadog::timing('request_time', $duration, 1, $tags);
     }


### PR DESCRIPTION
Defaults to still adding the url tag, with the new option allowing to disable it.

We're using this on a production site with lots of dynamic routes (e.g. paths containing user ids, etc) and the Datadog UI breaks when trying to display that many tags (i.e. when trying to select a tag for graphs/etc).