### PR TITLE
Use facade without an alias within middleware

### DIFF
--- a/src/Middleware/LaravelDatadogMiddleware.php
+++ b/src/Middleware/LaravelDatadogMiddleware.php
@@ -3,7 +3,7 @@
 namespace ChaseConey\LaravelDatadogHelper\Middleware;
 
 use Closure;
-use Datadog;
+use ChaseConey\LaravelDatadogHelper\Datadog;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 


### PR DESCRIPTION
The readme file states that using the `Datadog` alias for the facade is optional, but the middleware assumes that it is being used. With this change, using the middleware will work even if the alias has not been configured.