### PR TITLE
Ability to use socket instead of UDP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "datadog/php-datadogstatsd": "~1.0",
+    "datadog/php-datadogstatsd": "^1.4.0",
     "illuminate/support": "~5.1"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,12 @@
 {
-  "name": "fiftytruck/laravel-datadog-helper",
+  "name": "chaseconey/laravel-datadog-helper",
   "type": "library",
   "description": "A Laravel Datadog helper package.",
   "keywords": [
     "chaseconey",
-    "fiftytruck",
     "laravel-datadog-helper"
   ],
-  "homepage": "https://github.com/fiftytruck/laravel-datadog-helper",
+  "homepage": "https://github.com/chaseconey/laravel-datadog-helper",
   "license": "MIT",
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,13 @@
 {
-  "name": "chaseconey/laravel-datadog-helper",
+  "name": "fiftytruck/laravel-datadog-helper",
   "type": "library",
   "description": "A Laravel Datadog helper package.",
   "keywords": [
     "chaseconey",
+    "fiftytruck",
     "laravel-datadog-helper"
   ],
-  "homepage": "https://github.com/chaseconey/laravel-datadog-helper",
+  "homepage": "https://github.com/fiftytruck/laravel-datadog-helper",
   "license": "MIT",
   "authors": [
     {

--- a/config/datadog-helper.php
+++ b/config/datadog-helper.php
@@ -34,6 +34,8 @@ return [
 
     'statsd_port' => 8125,
 
+    'statsd_socket_path' => null,
+
     'global_tags' => [],
 
     'max_buffer_length' => 1,

--- a/src/LaravelDatadogHelperServiceProvider.php
+++ b/src/LaravelDatadogHelperServiceProvider.php
@@ -48,6 +48,7 @@ class LaravelDatadogHelperServiceProvider extends ServiceProvider
         $ddConfig = [
             'host' => $laravelConfig['statsd_server'],
             'port' => $laravelConfig['statsd_port'],
+            'socket_path' => $laravelConfig['statsd_socket_path'],
             'datadog_host' => $laravelConfig['datadog_host'],
             'api_key' => $laravelConfig['api_key'],
             'app_key' => $laravelConfig['application_key'],


### PR DESCRIPTION
For dockerized environments, it is easier to send metrics through a shared socket instead of an UDP connection. This PR adds the ability to use the socket_path configuration key of dogstatsd Datadog library.