### PR TITLE
Fixes chaseconey/laravel-datadog-helper#17

### DIFF
--- a/src/Datadog.php
+++ b/src/Datadog.php
@@ -6,6 +6,22 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @see \ChaseConey\LaravelDatadogHelper
+ * @see \Datadog\DogStatsd
+ *
+ * @method static void timing(string $stat, float $time, float $sampleRate = 1.0, array|string $tags = null)
+ * @method static void microtiming(string $stat, float $time, float $sampleRate = 1.0, array|string $tags = null)
+ * @method static void gauge(string $stat, float $value, float $sampleRate = 1.0, array|string $tags = null)
+ * @method static void histogram(string $stat, float $value, float $sampleRate = 1.0, array|string $tags = null)
+ * @method static void distribution(string $stat, float $value, float $sampleRate = 1.0, array|string $tags = null)
+ * @method static void set(string $stat, float $value, float $sampleRate = 1.0, array|string $tags = null)
+ * @method static void increment(string|array $stats, float $sampleRate = 1.0, array|string $tags = null, int $value = 1)
+ * @method static void decrement(string|array $stats, float $sampleRate = 1.0, array|string $tags = null, int $value = -1)
+ * @method static void updateStats(string|array $stats, int $delta = 1, float $sampleRate = 1.0, array|string $tags = null)
+ * @method static void send(array $data, float $sampleRate = 1.0, array|string $tags = null)
+ * @method static void service_check(string $name, int $status, array|string $tags = null, string $hostname = null, string $message = null, int $timestamp = null)
+ * @method static void report($udp_message)
+ * @method static void flush($udp_message)
+ * @method static boolean event(string $title, array $values = [])
  */
 class Datadog extends Facade
 {


### PR DESCRIPTION
These phpdoc annotations now allows PhpStorm to correctly suggest the same public methods that are available on `\Datadog\DogStatsd`

![image](https://user-images.githubusercontent.com/4628774/83919183-1204a680-a748-11ea-80ee-1cdfbc581391.png)

Fixes chaseconey/laravel-datadog-helper#17