### PR TITLE
Update datadog-helper , default config to null (to use default environment setting)

### DIFF
--- a/config/datadog-helper.php
+++ b/config/datadog-helper.php
@@ -30,9 +30,9 @@ return [
 
     'datadog_host' => 'https://app.datadoghq.com',
 
-    'statsd_server' => 'localhost',
+    'statsd_server' => null,
 
-    'statsd_port' => 8125,
+    'statsd_port' => null,
 
     'statsd_socket_path' => null,
 


### PR DESCRIPTION
Hi,

I want to use DD_AGENT_HOST , DD_DOGSTATSD_PORT environment, but config/datadog-helper.php use "localhost".

https://docs.datadoghq.com/developers/dogstatsd/?tab=php

PARAMETER | TYPE | DEFAULT | DESCRIPTION
-- | -- | -- | --
host | String | localhost | The host of your DogStatsD server. If this is not set the Agent looks at the DD_AGENT_HOSTenvironment variable.
port | Integer | 8125 | The port of your DogStatsD server. If this is not set, the Agent looks at the DD_DOGSTATSD_PORTenvironment variable.

I have to think use null for default.
Thank you.




